### PR TITLE
Fixed text clipping in Cross-Compatible sample

### DIFF
--- a/cross-compatible-js-sample/src/index.js
+++ b/cross-compatible-js-sample/src/index.js
@@ -134,6 +134,8 @@ function createLabel(e) {
       }];
 
       selection.insertionParent.addChild(label);
+
+      label.placeInParentCoordinates({ x: label.localBounds.x, y: label.localBounds.y}, { x: 0, y: 0});
     });
   }
 }


### PR DESCRIPTION
This PR includes a quick fix that addresses the problem of text labels being clipped when using the Cross-Compatible sample. They should now be placed at coordinates (0, 0) respective to the parent. This PR also makes this sample even with the version posted on the Photoshop sample repository